### PR TITLE
Sonar: не мерить покрытие на живом WMI — Quality Gate падал на main

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -2,6 +2,16 @@
 # для .NET (Automatic Analysis язык не поддерживает) — begin → build → test → end.
 # Результат уезжает на sonarcloud.io. Секрет SONAR_TOKEN секретам форков не виден,
 # поэтому анализ гоняем на push в main и вручную, а не на PR из форков.
+#
+# sonar.coverage.exclusions — из ИЗМЕРЕНИЯ покрытия исключены края, которые мы намеренно
+# не покрываем юнитами (политика из CLAUDE.md: чистую логику тестируем, UI и железо — глазами):
+# UI/WinForms, системная интеграция, точка входа, tools и два файла живого WMI —
+# MifsClient/MifsEventWatcher (они дёргают ManagementObject, без ноутбука не выполняются;
+# логика над ними тестируется через шов IMifsClient на фейках). Mifs.cs НЕ исключён:
+# это чистые таблицы и маппинги, они покрыты тестами и должны такими оставаться.
+# На статический анализ (баги, smells, уязвимости) исключение не влияет — только на coverage.
+# Важно: Quality Gate «Sonar way» требует ≥80% покрытия нового кода, а свой гейт на бесплатном
+# тарифе не завести (Team/Enterprise) — поэтому измеряем только то, что реально тестируем.
 name: sonarcloud
 
 on:
@@ -43,7 +53,7 @@ jobs:
           /d:sonar.token="$env:SONAR_TOKEN"
           /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
           /d:sonar.scanner.scanAll=false
-          /d:sonar.coverage.exclusions="src/Ui/**,src/SystemIntegration/**,src/Program.cs,tools/**"
+          /d:sonar.coverage.exclusions="src/Ui/**,src/SystemIntegration/**,src/Wmi/MifsClient.cs,src/Wmi/MifsEventWatcher.cs,src/Program.cs,tools/**"
 
       - name: Build
         run: dotnet build XiControl.sln -c Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,6 +216,13 @@ WMI-событий). `Program.cs`: single-instance mutex → DI-контейне
 - Тег с суффиксом через дефис (`v0.7.0-pre`) помечается pre-release и winget **не** трогает.
 - Каждый push в `main` собирает скользящий pre-release под тегом `pre` — всегда свежий билд из main;
   winget его не видит (слушает только `release: [released]`).
+- **SonarCloud** (`.github/workflows/sonar.yml`, только push в `main`): бесплатный тариф даёт лишь
+  встроенный Quality Gate «Sonar way» — свой не завести (Team/Enterprise), а он требует **≥80%
+  покрытия нового кода**. Поэтому из ИЗМЕРЕНИЯ покрытия (`sonar.coverage.exclusions`) исключены
+  края, которые мы намеренно не покрываем юнитами: `src/Ui/**`, `src/SystemIntegration/**`,
+  `Program.cs`, `tools/**` и живой WMI — `MifsClient.cs`/`MifsEventWatcher.cs`. Чистая логика
+  (`Mifs.cs`, конфиг, guard-ы, роутер) измеряется и должна оставаться покрытой. Добавляешь новый
+  файл с живым железом — впиши его в исключения, иначе гейт покраснеет на ровном месте.
 - Локальная сборка помечается версией `0.0.0-dev` (дев-дефолт в `XiControl.csproj`, суффикс виден
   в AboutTab); реальную версию подставляет CI из тега: `publish -p:Version=X.Y.Z`.
 


### PR DESCRIPTION
## Проблема

После слияния XIC-4 на `main` висит красный крестик: проверка **SonarCloud Code Analysis** — `failure`. Сам воркфлоу отрабатывает успешно, падает именно Quality Gate.

Точная причина (из публичного API проекта):

| Метрика | Значение |
|---|---|
| `new_coverage` | **78.1%** при пороге **80%** |
| `new_lines` | 422 |
| `new_lines_to_cover` | 22 |
| `new_uncovered_lines` | **6 — все в `src/Wmi/MifsClient.cs`** |

Это `GetChargeLimit`/`SetChargeLimit` из XIC-4. Покрыть их юнит-тестами нельзя в принципе: они дёргают живой WMI через `ManagementObject.InvokeMethod` и без ноутбука просто не выполняются. Логика над ними и так тестируется — через шов `IMifsClient` на фейках (5 кейсов `SetCareLimit` в `AppControllerTests`).

Поднять порог или завести свой Quality Gate **нельзя**: пользовательские гейты доступны только в планах Team и Enterprise, а встроенный «Sonar way» жёстко требует 80% на новом коде. У нас бесплатный тариф для открытых проектов.

## Решение

Приводим **измерение** покрытия в соответствие с политикой тестирования, которая в проекте и так действует (CLAUDE.md: «чистую логику покрывай тестом, UI и железо — глазами»). `src/Ui/**` и `src/SystemIntegration/**` по этой причине исключены давно — добавляем к ним два файла живого WMI:

```
src/Wmi/MifsClient.cs, src/Wmi/MifsEventWatcher.cs
```

Что важно:

- **`Mifs.cs` НЕ исключён** — это чистые таблицы и маппинги кодов, они покрыты `ChargeLevelsTests` и должны оставаться измеряемыми. Исключены ровно те два файла в `src/Wmi/`, которые реально ходят в WMI (проверил `grep` по `ManagementObject`/`ManagementEventWatcher`).
- **На поиск багов, smells и уязвимостей это не влияет** — `sonar.coverage.exclusions` трогает только метрику покрытия, статический анализ по этим файлам идёт как шёл.
- Правило записано в CLAUDE.md (раздел «Релизы и CI»), чтобы следующий файл с живым железом не ронял гейт на ровном месте.

## Проверка

Воркфлоу `sonar.yml` запускается только на push в `main`, поэтому в самом PR гейт не пересчитается — станет зелёным на первом пуше после слияния: шесть непокрытых строк уходят из измерения, остаётся 16 из 16 покрытых.

Правки только в конфигурации CI и документации — код не тронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)