### PR TITLE
Sonar: приём «первый объект WMI-запроса» вынесен в WmiQuery (S1751)

### DIFF
--- a/src/SystemIntegration/Brightness.cs
+++ b/src/SystemIntegration/Brightness.cs
@@ -26,12 +26,10 @@ public static class Brightness
         {
             using var s = new ManagementObjectSearcher(ScopePath,
                 "SELECT CurrentBrightness FROM WmiMonitorBrightness");
-            foreach (ManagementObject mo in s.Get())
-                using (mo)
-                    return Convert.ToInt32(mo["CurrentBrightness"], System.Globalization.CultureInfo.InvariantCulture);
+            return WmiQuery.First(s, mo =>
+                Convert.ToInt32(mo["CurrentBrightness"], System.Globalization.CultureInfo.InvariantCulture));
         }
-        catch (Exception ex) { Log.Ex("Brightness.Get", ex); }
-        return null;
+        catch (Exception ex) { Log.Ex("Brightness.Get", ex); return null; }
     }
 
     /// <summary>

--- a/src/SystemIntegration/SystemInfo.cs
+++ b/src/SystemIntegration/SystemInfo.cs
@@ -109,11 +109,8 @@ public sealed class SystemInfo
         try
         {
             using var s = new ManagementObjectSearcher(wql);
-            foreach (ManagementObject mo in s.Get())
-                using (mo)
-                    return mo[field]?.ToString();
+            return WmiQuery.FirstString(s, mo => mo[field]?.ToString());
         }
-        catch (Exception ex) { Log.Ex($"SystemInfo.Query({field})", ex); }
-        return null;
+        catch (Exception ex) { Log.Ex($"SystemInfo.Query({field})", ex); return null; }
     }
 }

--- a/src/SystemIntegration/WmiQuery.cs
+++ b/src/SystemIntegration/WmiQuery.cs
@@ -1,0 +1,36 @@
+using System.Management;
+
+namespace XiControl.SystemIntegration;
+
+/// <summary>
+/// «Первый объект WMI-запроса» — наш типовой приём: яркость, поля BIOS, статус батареи
+/// существуют в единственном экземпляре. Раньше это писалось циклом с return на первой
+/// итерации — читателю приходилось догадываться, что перебора не будет (и SonarCloud S1751
+/// резонно спотыкался о «цикл, который никогда не повторяется»). Здесь намерение названо
+/// словом, а disposal коллекции и объекта живёт в одном месте. Исключения намеренно не
+/// глотаются: у каждого вызывающего свой контекст лога и свой фолбэк.
+/// </summary>
+public static class WmiQuery
+{
+    /// <summary>Первый объект, спроецированный в значимый тип; null — объектов нет.
+    /// Именно null, а не default(T): ноль спутался бы с валидной яркостью или мощностью.</summary>
+    public static T? First<T>(ManagementObjectSearcher searcher, Func<ManagementObject, T> map) where T : struct
+    {
+        using var all = searcher.Get();
+        using var e = all.GetEnumerator();
+        if (!e.MoveNext()) return null;
+        using var mo = (ManagementObject)e.Current;
+        return map(mo);
+    }
+
+    /// <summary>То же для строкового результата (поля BIOS/платы в SystemInfo).
+    /// Отдельным именем: перегрузка по одной лишь nullable-аннотации невозможна (CS0111).</summary>
+    public static string? FirstString(ManagementObjectSearcher searcher, Func<ManagementObject, string?> map)
+    {
+        using var all = searcher.Get();
+        using var e = all.GetEnumerator();
+        if (!e.MoveNext()) return null;
+        using var mo = (ManagementObject)e.Current;
+        return map(mo);
+    }
+}

--- a/src/Ui/MonitorForm.cs
+++ b/src/Ui/MonitorForm.cs
@@ -378,18 +378,16 @@ public sealed class MonitorForm : FlyoutForm
         {
             _battery ??= new ManagementObjectSearcher(@"root\wmi",
                 "SELECT ChargeRate, DischargeRate, Discharging FROM BatteryStatus");
-            foreach (ManagementObject o in _battery.Get())
+            return SystemIntegration.WmiQuery.First(_battery, o =>
             {
                 bool discharging = (bool)o["Discharging"];
                 uint rate = discharging ? (uint)(int)o["DischargeRate"] : (uint)(int)o["ChargeRate"];
-                o.Dispose();
                 if (rate == 0) return float.NaN;
                 float w = rate / 1000f;
                 return discharging ? -w : w;   // разряд — вниз (минус), заряд — вверх (плюс)
-            }
+            }) ?? float.NaN;                   // датчика нет вовсе — как и раньше, «неизвестно»
         }
-        catch (Exception ex) { Log.Ex("Monitor.Power", ex); _battery = null; }
-        return float.NaN;
+        catch (Exception ex) { Log.Ex("Monitor.Power", ex); _battery = null; return float.NaN; }
     }
 
     // ---------- отрисовка ----------

--- a/tools/IconPreview/SvgGen.cs
+++ b/tools/IconPreview/SvgGen.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
 using System.Text;
 
+namespace XiControl.Ui; // как Icons.cs: генератор живёт рядом с геометрией иконок
+
 /// <summary>
 /// Генерирует SVG-версии иконок (та же геометрия, что в Icons.cs) и собирает лист,
 /// как в PNG-превью. Координаты считаются кодом — без ручной арифметики.


### PR DESCRIPTION
Чинит красный Quality Gate после релиза 0.11.0: `new_reliability_rating = 3` из-за четырёх багов Sonar, все — не про поведение.

## Что сделано

- **`WmiQuery.First/FirstString`** — приём «взять первый экземпляр WMI-запроса», который раньше писался циклом с `return` на первой итерации (S1751), назван словом. Три вызова: `Brightness.Get`, `SystemInfo.Query`, `MonitorForm.SamplePowerWattsWmi`. Disposal коллекции/объекта централизован; исключения намеренно не глотаются — try/catch с контекстом лога остаётся у вызывающих.
- **`SvgGen`** (tools/IconPreview) обёрнут в `namespace XiControl.Ui` — как соседний `Icons.cs` (S3903).

## Почему не исключение в .editorconfig

S1751 ловит настоящие баги (случайный `return`/`break` в цикле, который должен перебрать всё). Глушить его по всему проекту ради одной идиомы — терять защиту; сама идиома выражается лучше — хелпером.

## Поведение

Не менялось: те же null/NaN-фолбэки, `MonitorForm` сохраняет кэш searcher-а. `dotnet build` 0/0, `dotnet test` — 331 зелёный. Sonar перепроверит на пуше в main после мержа.

🤖 Generated with [Claude Code](https://claude.com/claude-code)