### PR TITLE
chore: расширенный .gitignore (из PR #40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,17 @@
 # .NET build output
 [Bb]in/
 [Oo]bj/
+[Aa]rtifacts/
 *.user
+*.suo
+*.rsuser
+*.userosscache
+*.sln.docstates
 
 # Rider / VS
 .idea/
 .vs/
+.vscode/
 
 # Publish
 publish/
@@ -14,6 +20,21 @@ publish/
 # Test coverage output (coverlet)
 [Tt]est[Rr]esults/
 .sonarqube/
+[Cc]overage/
+[Cc]overage[Rr]eport/
+BenchmarkDotNet.Artifacts/
+*.trx
+*.coverage
+*.coveragexml
+
+# Local diagnostics / editor and OS debris
+*.log
+*.tmp
+*.bak
+*.orig
+.DS_Store
+Thumbs.db
+desktop.ini
 
 # рабочие материалы исследования — только локально
 reference/


### PR DESCRIPTION
Из большого [PR #40](https://github.com/Oksion/XiControl/pull/40) вынесена единственная часть, которая применима к `main` как есть и ни от чего не зависит.

Добавлено: `.vscode/`, `[Aa]rtifacts/`, артефакты покрытия (`*.trx`, `*.coverage`, `*.coveragexml`, `[Cc]overage/`, `[Cc]overage[Rr]eport/`), `BenchmarkDotNet.Artifacts/`, мусор редакторов и ОС (`*.suo`, `*.rsuser`, `*.userosscache`, `*.sln.docstates`, `*.log`, `*.tmp`, `*.bak`, `*.orig`, `.DS_Store`, `Thumbs.db`, `desktop.ini`).

Проверил, что `*.log` ничего живого не прячет: рантайм-журнал зовётся `log.txt` и лежит в каталоге данных, а не в репозитории.

Авторство куска сохранено через `Co-authored-by`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)