### PR TITLE
feat(power): reliable refresh-rate guard and RAPL fallback

### DIFF
--- a/src/SystemIntegration/IPowerEvents.cs
+++ b/src/SystemIntegration/IPowerEvents.cs
@@ -43,7 +43,7 @@ public static class PowerLine
 {
     public static bool IsOnline(PowerLineStatus status) => status != PowerLineStatus.Offline;
 
-    public static bool IsOnline() => IsOnline(SystemInformation.PowerStatus.PowerLineStatus);
+    public static bool IsOnline() => IsOnline(PowerStatus.Read().LineStatus);
 }
 
 /// <summary>
@@ -70,7 +70,7 @@ public sealed class SystemEventsSource : IPowerEvents, IDisplayEvents
 
     public bool IsOnline => PowerLine.IsOnline();
 
-    public float BatteryLifePercent => SystemInformation.PowerStatus.BatteryLifePercent;
+    public float BatteryLifePercent => PowerStatus.Read().BatteryLifePercent;
 
     public SystemEventsSource()
     {

--- a/src/SystemIntegration/PowerStatus.cs
+++ b/src/SystemIntegration/PowerStatus.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices;
+
+namespace XiControl.SystemIntegration;
+
+/// <summary>Значения совпадают с Win32 SYSTEM_POWER_STATUS.ACLineStatus.</summary>
+public enum PowerLineStatus : byte
+{
+    Offline = 0,
+    Online = 1,
+    Unknown = 255,
+}
+
+/// <summary>Снимок состояния питания из Win32 GetSystemPowerStatus.</summary>
+public readonly record struct PowerSnapshot(PowerLineStatus LineStatus, float BatteryLifePercent)
+{
+    public int? BatteryPercent => BatteryLifePercent is >= 0f and <= 1f
+        ? (int)Math.Round(BatteryLifePercent * 100)
+        : null;
+}
+
+/// <summary>Тонкая Win32-обёртка без зависимости от WinForms.</summary>
+public static class PowerStatus
+{
+    public static PowerSnapshot Read()
+    {
+        if (!GetSystemPowerStatus(out var status))
+            return new PowerSnapshot(PowerLineStatus.Unknown, 2.55f);
+
+        float battery = status.BatteryLifePercent == byte.MaxValue
+            ? 2.55f
+            : status.BatteryLifePercent / 100f;
+        return new PowerSnapshot((PowerLineStatus)status.AcLineStatus, battery);
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct SystemPowerStatus
+    {
+        public byte AcLineStatus;
+        public byte BatteryFlag;
+        public byte BatteryLifePercent;
+        public byte SystemStatusFlag;
+        public uint BatteryLifeTime;
+        public uint BatteryFullLifeTime;
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetSystemPowerStatus(out SystemPowerStatus systemPowerStatus);
+}

--- a/src/SystemIntegration/RefreshRate.cs
+++ b/src/SystemIntegration/RefreshRate.cs
@@ -82,10 +82,65 @@ public static class RefreshRate
         catch (Exception ex) { Log.Ex("RefreshRate.Resolve", ex); return null; }
     }
 
+    /// <summary>Поддерживаемые частоты текущего разрешения встроенной панели.
+    /// Пустой массив означает, что панель сейчас не активна или драйвер не отдал режимы.</summary>
+    public static int[] Supported()
+    {
+        try
+        {
+            if (InternalPanel() is not string panel) return [];
+            var cur = NewDevmode();
+            if (!EnumDisplaySettingsExW(panel, EnumCurrentSettings, ref cur, 0)) return [];
+            return SupportedRates(panel, cur);
+        }
+        catch (Exception ex) { Log.Ex("RefreshRate.Supported", ex); return []; }
+    }
+
+    /// <summary>Автопереключение имеет смысл только при наличии хотя бы двух режимов.</summary>
+    public static bool SupportsAutomaticSwitching() => HasMultipleRates(Supported());
+
+    internal static bool HasMultipleRates(IEnumerable<int> rates) =>
+        rates.Where(x => x > 1).Distinct().Take(2).Count() == 2;
+
     /// <summary>Установить ближайшую к hz поддерживаемую частоту встроенной панели.
     /// true — установлена (или уже стояла). Можно звать с любого потока; параллельные
     /// вызовы сериализуются.</summary>
     public static bool Apply(int hz) => ApplyCore(hz) == ApplyResult.Ok;
+
+    /// <summary>Переключить встроенную панель на следующую поддерживаемую частоту и вернуть
+    /// реально установленное значение. null — панель не активна или смена не удалась.</summary>
+    public static int? Cycle()
+    {
+        lock (Sync)
+        {
+            try
+            {
+                if (InternalPanel() is not string panel) return null;
+                var cur = NewDevmode();
+                if (!EnumDisplaySettingsExW(panel, EnumCurrentSettings, ref cur, 0)) return null;
+
+                var rates = SupportedRates(panel, cur);
+                if (NextRate((int)cur.dmDisplayFrequency, rates) is not int next) return null;
+                if ((int)cur.dmDisplayFrequency == next) return next;
+
+                cur.dmDisplayFrequency = (uint)next;
+                cur.dmFields = DmPelsWidth | DmPelsHeight | DmBitsPerPel | DmDisplayFrequency;
+                return ChangeDisplaySettingsExW(panel, ref cur, IntPtr.Zero, CdsUpdateRegistry, IntPtr.Zero)
+                    == DispChangeSuccessful ? next : null;
+            }
+            catch (Exception ex) { Log.Ex("RefreshRate.Cycle", ex); return null; }
+        }
+    }
+
+    /// <summary>Следующая частота по возрастанию; после максимальной — минимальная.</summary>
+    internal static int? NextRate(int current, IEnumerable<int> supported)
+    {
+        int[] rates = supported.Where(x => x > 1).Distinct().Order().ToArray();
+        if (rates.Length == 0) return null;
+        foreach (int rate in rates)
+            if (rate > current) return rate;
+        return rates[0];
+    }
 
     /// <summary>«Панели нет» — не сбой, а нормальный расклад, и звать его так в логе нельзя:
     /// разбирая чужой log.txt, «не удалось установить» отправит искать несуществующую поломку.</summary>
@@ -127,6 +182,17 @@ public static class RefreshRate
     private static int Nearest(string panel, Devmode cur, int hz)
     {
         int best = 0;
+        foreach (int f in SupportedRates(panel, cur))
+        {
+            if (best == 0 || Math.Abs(f - hz) < Math.Abs(best - hz) ||
+                (Math.Abs(f - hz) == Math.Abs(best - hz) && f > best)) best = f;
+        }
+        return best;
+    }
+
+    private static int[] SupportedRates(string panel, Devmode cur)
+    {
+        var rates = new HashSet<int>();
         var probe = NewDevmode();
         for (int i = 0; EnumDisplaySettingsExW(panel, i, ref probe, 0); i++)
         {
@@ -134,10 +200,9 @@ public static class RefreshRate
                 probe.dmBitsPerPel != cur.dmBitsPerPel) continue;
             int f = (int)probe.dmDisplayFrequency;
             if (f <= 1) continue; // 0/1 — «аппаратная по умолчанию», не частота
-            if (best == 0 || Math.Abs(f - hz) < Math.Abs(best - hz) ||
-                (Math.Abs(f - hz) == Math.Abs(best - hz) && f > best)) best = f;
+            rates.Add(f);
         }
-        return best;
+        return rates.Order().ToArray();
     }
 
     // ---- Поиск встроенной панели (CCD API, user32; driver-free) ----

--- a/src/SystemIntegration/RefreshRateGuard.cs
+++ b/src/SystemIntegration/RefreshRateGuard.cs
@@ -6,12 +6,14 @@ namespace XiControl.SystemIntegration;
 /// <summary>
 /// Авто-герцовка: держит частоту экрана в соответствии с питанием
 /// (сеть → AcRefreshRate, батарея → BatteryRefreshRate), пока опция включена.
-/// Срабатывает на смену питания и выход из сна; события идут пачкой — дебаунс.
+/// Срабатывает на смену питания и выход из сна; события идут пачкой — дебаунс. После
+/// выхода из сна один раз проверяет питание через 15 секунд. Постоянный опрос включается
+/// только если эта проверка обнаружила переход AC↔батарея без события StatusChange.
 ///
 /// Дополнительно, если включён <see cref="AppConfig.HoldRefreshRate"/> — на смену режима экрана:
 /// частоту мог сменить кто угодно (пользователь в параметрах Windows, чужая утилита, драйвер
 /// после сброса), и без этого настройка тихо не держалась бы до следующего события питания.
-/// Опроса нет и не должно быть — только события.
+/// В норме опроса нет: watchdog остаётся одноразовой проверкой после resume.
 /// </summary>
 public sealed class RefreshRateGuard : IDisposable
 {
@@ -19,16 +21,31 @@ public sealed class RefreshRateGuard : IDisposable
     private readonly IPowerEvents _power;
     private readonly IDisplayEvents _display;
     private readonly IAppTimer _debounce;
+    private readonly IAppTimer _watchdog;
+    private readonly Action _apply;
+    private bool _lastOnline;
+    private bool _persistentWatchdog;
 
-    public RefreshRateGuard(AppConfig cfg, IPowerEvents power, IDisplayEvents display, IAppTimer? debounce = null)
+    public RefreshRateGuard(AppConfig cfg, IPowerEvents power, IDisplayEvents display,
+        IAppTimer? debounce = null)
+        : this(cfg, power, display, debounce, null, null) { }
+
+    internal RefreshRateGuard(AppConfig cfg, IPowerEvents power, IDisplayEvents display,
+        IAppTimer? debounce, IAppTimer? watchdog, Action? apply)
     {
         _cfg = cfg;
         _power = power;
         _display = display;
+        _apply = apply ?? (() => RefreshRate.ApplyForPower(_cfg));
+        _lastOnline = _power.IsOnline;
 
         _debounce = debounce ?? new UiTimer();
         _debounce.Interval = 1500;
-        _debounce.Tick += () => { _debounce.Stop(); Reapply(); };
+        _debounce.Tick += OnDebounce;
+
+        _watchdog = watchdog ?? new UiTimer();
+        _watchdog.Interval = 15_000;
+        _watchdog.Tick += VerifyPower;
 
         _power.PowerModeChanged += OnPowerModeChanged;
         _display.DisplaySettingsChanged += OnDisplaySettingsChanged;
@@ -36,8 +53,42 @@ public sealed class RefreshRateGuard : IDisposable
 
     private void OnPowerModeChanged(PowerModes mode)
     {
-        // Resume — выход из сна; StatusChange — смена питания AC↔батарея
-        if (mode is PowerModes.Resume or PowerModes.StatusChange) Arm();
+        if (mode == PowerModes.StatusChange)
+        {
+            _lastOnline = _power.IsOnline;
+            Arm();
+            // Событие пришло штатно — одноразовая post-resume проверка уже не нужна.
+            if (!_persistentWatchdog) _watchdog.Stop();
+        }
+        else if (mode == PowerModes.Resume)
+        {
+            Arm();
+            if (!_persistentWatchdog)
+            {
+                // Не обновляем _lastOnline: watchdog должен заметить смену питания во сне,
+                // если Windows не прислала StatusChange после пробуждения.
+                _watchdog.Stop();
+                _watchdog.Start();
+            }
+        }
+    }
+
+    private void VerifyPower()
+    {
+        bool online = _power.IsOnline;
+        if (online != _lastOnline)
+        {
+            _lastOnline = online;
+            Arm();
+            // Обнаружили реальный пропуск StatusChange: оставляем 15-секундный timer
+            // работать постоянно для этой сессии.
+            _persistentWatchdog = true;
+        }
+        else if (!_persistentWatchdog)
+        {
+            // Обычный случай: одноразовая проверка после resume ничего не нашла.
+            _watchdog.Stop();
+        }
     }
 
     // Режим экрана изменился. Зацикливания нет: наше собственное применение тоже поднимет это
@@ -55,13 +106,24 @@ public sealed class RefreshRateGuard : IDisposable
         _debounce.Start();
     }
 
+    private void OnDebounce()
+    {
+        _debounce.Stop();
+        Reapply();
+    }
+
     /// <summary>Применить частоту по текущему питанию прямо сейчас (старт/включение опции).</summary>
-    public void Reapply() => RefreshRate.ApplyForPower(_cfg);
+    public void Reapply() => _apply();
 
     public void Dispose()
     {
         _power.PowerModeChanged -= OnPowerModeChanged;
         _display.DisplaySettingsChanged -= OnDisplaySettingsChanged;
+        _debounce.Tick -= OnDebounce;
+        _watchdog.Tick -= VerifyPower;
+        _debounce.Stop();
+        _watchdog.Stop();
         _debounce.Dispose();
+        _watchdog.Dispose();
     }
 }

--- a/src/SystemIntegration/TrayMetrics.cs
+++ b/src/SystemIntegration/TrayMetrics.cs
@@ -154,6 +154,50 @@ public sealed class DptfTemperature : IDisposable
 }
 
 /// <summary>
+/// Мощность CPU package из штатного Windows Energy Meter. На части моделей Xiaomi
+/// прошивка не сообщает мощность адаптера/батареи при работе от сети, но Intel RAPL
+/// остаётся доступен через этот performance provider. Отрицательный знак сохраняет
+/// соглашение PowerDraw: расход отрицательный, заряд батареи положительный.
+/// </summary>
+public sealed class EnergyMeterPower : IDisposable
+{
+    private ManagementObjectSearcher? _query;
+    private bool _off;
+
+    public float ReadWatts()
+    {
+        if (_off) return float.NaN;
+        try
+        {
+            _query ??= new ManagementObjectSearcher(@"root\cimv2",
+                "SELECT Power FROM Win32_PerfFormattedData_PowerMeterCounter_EnergyMeter " +
+                "WHERE Name = 'RAPL_Package0_PKG'");
+            foreach (ManagementObject item in _query.Get())
+            {
+                object? raw = item["Power"];
+                item.Dispose();
+                if (raw is null) continue;
+                return ToConsumptionWatts(Convert.ToUInt64(raw, CultureInfo.InvariantCulture));
+            }
+            return float.NaN;
+        }
+        catch (Exception ex)
+        {
+            Log.Ex("EnergyMeter", ex);
+            _query?.Dispose();
+            _query = null;
+            _off = true;
+            return float.NaN;
+        }
+    }
+
+    internal static float ToConsumptionWatts(ulong milliwatts) =>
+        milliwatts > 0 ? -(milliwatts / 1000f) : float.NaN;
+
+    public void Dispose() => _query?.Dispose();
+}
+
+/// <summary>
 /// Источник значения для индикатора: фасад над PowerDraw/CpuLoad/GpuTelemetry/MemoryLoad/DPTF.
 /// Всё лениво: создаётся только внутренность выбранной метрики, остальные не трогаются.
 /// NaN = данных нет (значок показывает «—»): от сети без заряда, не-Intel GPU, нет DPTF.
@@ -162,6 +206,7 @@ public sealed class TrayMetricSource : IDisposable
 {
     private readonly TrayMetric _kind;
     private PowerDraw? _power;
+    private EnergyMeterPower? _energyMeter;
     private CpuLoad? _cpu;
     private GpuTelemetry? _gpu;
     private DptfTemperature? _temp;
@@ -180,7 +225,9 @@ public sealed class TrayMetricSource : IDisposable
     private float ReadPower()
     {
         _power ??= new PowerDraw();
-        return _power.TryReadWatts(out float w) ? w : float.NaN;
+        if (_power.TryReadWatts(out float watts) && !float.IsNaN(watts)) return watts;
+        _energyMeter ??= new EnergyMeterPower();
+        return _energyMeter.ReadWatts();
     }
 
     private float ReadGpu()
@@ -192,6 +239,7 @@ public sealed class TrayMetricSource : IDisposable
     public void Dispose()
     {
         _power?.Dispose();
+        _energyMeter?.Dispose();
         _gpu?.Dispose();
         _temp?.Dispose();
     }

--- a/src/Ui/TrayApp.cs
+++ b/src/Ui/TrayApp.cs
@@ -5,6 +5,7 @@ using XiControl.Input;
 using XiControl.Localization;
 using XiControl.SystemIntegration;
 using XiControl.Wmi;
+using NativePowerStatus = XiControl.SystemIntegration.PowerStatus;
 
 namespace XiControl.Ui;
 
@@ -319,8 +320,7 @@ public sealed class TrayApp : IDisposable
     {
         string s = Loc.T("app.name");
         if (mode is PerfMode m && ModeUi.Key(m) is string key) s += " • " + Loc.T(key);
-        float f = SystemInformation.PowerStatus.BatteryLifePercent;
-        if (f is >= 0f and <= 1f) s += $" • {(int)Math.Round(f * 100)}%";
+        if (NativePowerStatus.Read().BatteryPercent is int pct) s += $" • {pct}%";
         return s.Length <= 127 ? s : s[..127];
     }
 
@@ -416,9 +416,8 @@ public sealed class TrayApp : IDisposable
 
     private void ShowPowerOsd(bool online)
     {
-        var ps = SystemInformation.PowerStatus;
-        float f = ps.BatteryLifePercent;
-        string? sub = (f >= 0f && f <= 1f) ? Loc.T("osd.level", (int)Math.Round(f * 100)) : null;
+        int? pct = NativePowerStatus.Read().BatteryPercent;
+        string? sub = pct is int level ? Loc.T("osd.level", level) : null;
 
         // авто-герцовка включена — дописываем фактическую частоту (ближайшую поддерживаемую;
         // сам переход сделает RefreshRateGuard после дебаунса)
@@ -504,9 +503,8 @@ public sealed class TrayApp : IDisposable
     // (мы на потоке API, не UI). PowerDraw под замком: запросы могут прийти параллельно.
     private ApiStatus ApiStatusSnapshot()
     {
-        var ps = SystemInformation.PowerStatus;
-        float f = ps.BatteryLifePercent;
-        int? pct = (f >= 0f && f <= 1f) ? (int)Math.Round(f * 100) : null;
+        var ps = NativePowerStatus.Read();
+        int? pct = ps.BatteryPercent;
         float? watts = null;
         lock (_apiLock)
         {
@@ -517,7 +515,7 @@ public sealed class TrayApp : IDisposable
         return new ApiStatus(
             mode?.ToString() ?? "unknown",
             _cfg.ChargeCare, _cfg.TravelMode, _cfg.Awake,
-            pct, PowerLine.IsOnline(ps.PowerLineStatus), watts,
+            pct, PowerLine.IsOnline(ps.LineStatus), watts,
             BatteryReportCached().HealthPercent);
     }
 

--- a/tests/XiControl.Tests/PowerLineTests.cs
+++ b/tests/XiControl.Tests/PowerLineTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using XiControl.SystemIntegration;
 using Xunit;
+using NativePowerLineStatus = XiControl.SystemIntegration.PowerLineStatus;
 
 namespace XiControl.Tests;
 
@@ -10,9 +11,23 @@ namespace XiControl.Tests;
 public sealed class PowerLineTests
 {
     [Theory]
-    [InlineData(PowerLineStatus.Online, true)]
-    [InlineData(PowerLineStatus.Unknown, true)]   // 255 бывает сразу после resume — не повод троттлить
-    [InlineData(PowerLineStatus.Offline, false)]
-    public void IsOnline_TreatsOnlyOfflineAsBattery(PowerLineStatus status, bool expected) =>
+    [InlineData(NativePowerLineStatus.Online, true)]
+    [InlineData(NativePowerLineStatus.Unknown, true)]   // 255 бывает сразу после resume — не повод троттлить
+    [InlineData(NativePowerLineStatus.Offline, false)]
+    public void IsOnline_TreatsOnlyOfflineAsBattery(NativePowerLineStatus status, bool expected) =>
         PowerLine.IsOnline(status).Should().Be(expected);
+
+    [Theory]
+    [InlineData(0f, 0)]
+    [InlineData(0.504f, 50)]
+    [InlineData(1f, 100)]
+    public void BatteryPercent_RoundsValidWin32Fraction(float fraction, int expected) =>
+        new PowerSnapshot(NativePowerLineStatus.Online, fraction).BatteryPercent.Should().Be(expected);
+
+    [Theory]
+    [InlineData(-1f)]
+    [InlineData(1.01f)]
+    [InlineData(2.55f)]
+    public void BatteryPercent_RejectsUnknownOrInvalidFraction(float fraction) =>
+        new PowerSnapshot(NativePowerLineStatus.Unknown, fraction).BatteryPercent.Should().BeNull();
 }

--- a/tests/XiControl.Tests/RefreshRateGuardTests.cs
+++ b/tests/XiControl.Tests/RefreshRateGuardTests.cs
@@ -14,9 +14,12 @@ public sealed class RefreshRateGuardTests
 {
     private readonly FakePowerEvents _power = new();
     private readonly FakeDisplayEvents _display = new();
-    private readonly FakeTimer _timer = new();
+    private readonly FakeTimer _debounce = new();
+    private readonly FakeTimer _watchdog = new();
+    private int _applies;
 
-    private RefreshRateGuard Guard(AppConfig cfg) => new(cfg, _power, _display, _timer);
+    private RefreshRateGuard Guard(AppConfig cfg) =>
+        new(cfg, _power, _display, _debounce, _watchdog, () => _applies++);
 
     [Theory]
     [InlineData(PowerModes.StatusChange)]
@@ -28,9 +31,10 @@ public sealed class RefreshRateGuardTests
 
         _power.RaisePower(mode);
 
-        _timer.Running.Should().BeTrue();
-        _timer.Fire(); // AutoRefreshRate=false → ApplyForPower выходит сразу, экран не трогаем
-        _timer.Running.Should().BeFalse();
+        _debounce.Running.Should().BeTrue();
+        _debounce.Fire();
+        _debounce.Running.Should().BeFalse();
+        _applies.Should().Be(1);
     }
 
     [Fact]
@@ -41,7 +45,7 @@ public sealed class RefreshRateGuardTests
 
         _power.RaisePower(PowerModes.Suspend);
 
-        _timer.Running.Should().BeFalse();
+        _debounce.Running.Should().BeFalse();
     }
 
     // XIC-22: реакция на чужую смену режима экрана — только при включённой опции,
@@ -54,7 +58,7 @@ public sealed class RefreshRateGuardTests
 
         _display.RaiseDisplayChanged();
 
-        _timer.Running.Should().BeTrue();
+        _debounce.Running.Should().BeTrue();
     }
 
     [Fact]
@@ -65,7 +69,7 @@ public sealed class RefreshRateGuardTests
 
         _display.RaiseDisplayChanged();
 
-        _timer.Running.Should().BeFalse("по умолчанию опция выключена — поведение прежнее");
+        _debounce.Running.Should().BeFalse("по умолчанию опция выключена — поведение прежнее");
     }
 
     [Fact]
@@ -82,9 +86,76 @@ public sealed class RefreshRateGuardTests
         guard.Dispose();
 
         _power.RaisePower(PowerModes.StatusChange);
-        _timer.Running.Should().BeFalse();
+        _debounce.Running.Should().BeFalse();
 
         _display.RaiseDisplayChanged();
-        _timer.Running.Should().BeFalse("подписка на события экрана тоже снимается");
+        _debounce.Running.Should().BeFalse("подписка на события экрана тоже снимается");
+        _watchdog.Running.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Watchdog_IsIdleUntilResume()
+    {
+        using var guard = Guard(new AppConfig());
+
+        _watchdog.Running.Should().BeFalse();
+        _watchdog.Interval.Should().Be(15_000);
+    }
+
+    [Fact]
+    public void Resume_StartsOnePostResumeProbe()
+    {
+        using var guard = Guard(new AppConfig());
+
+        _power.RaisePower(PowerModes.Resume);
+
+        _watchdog.Running.Should().BeTrue();
+        _watchdog.Starts.Should().Be(1);
+    }
+
+    [Fact]
+    public void UnchangedPostResumeProbe_StopsWithoutBecomingPersistent()
+    {
+        using var guard = Guard(new AppConfig());
+        _power.RaisePower(PowerModes.Resume);
+
+        _watchdog.Fire();
+
+        _watchdog.Running.Should().BeFalse();
+        _debounce.Fire();
+        _applies.Should().Be(1, "resume itself still schedules the normal reapply");
+    }
+
+    [Fact]
+    public void MissedPowerTransition_MakesWatchdogPersistent()
+    {
+        using var guard = Guard(new AppConfig());
+        _power.RaisePower(PowerModes.Resume);
+        _debounce.Fire();
+        _power.IsOnline = false; // Windows не прислала StatusChange
+
+        _watchdog.Fire();
+
+        _watchdog.Running.Should().BeTrue("обнаружен пропущенный переход питания");
+        _debounce.Running.Should().BeTrue();
+        _debounce.Fire();
+        _applies.Should().Be(2);
+
+        _power.IsOnline = true;
+        _watchdog.Fire();
+        _debounce.Running.Should().BeTrue("постоянный watchdog замечает следующие переходы");
+    }
+
+    [Fact]
+    public void StatusChangeBeforeProbe_CancelsOneShotWatchdog()
+    {
+        using var guard = Guard(new AppConfig());
+        _power.RaisePower(PowerModes.Resume);
+        _power.IsOnline = false;
+
+        _power.RaisePower(PowerModes.StatusChange);
+
+        _watchdog.Running.Should().BeFalse();
+        _debounce.Running.Should().BeTrue();
     }
 }

--- a/tests/XiControl.Tests/RefreshRateTests.cs
+++ b/tests/XiControl.Tests/RefreshRateTests.cs
@@ -1,0 +1,27 @@
+using FluentAssertions;
+using XiControl.SystemIntegration;
+using Xunit;
+
+namespace XiControl.Tests;
+
+public sealed class RefreshRateTests
+{
+    [Theory]
+    [InlineData(60, 90)]
+    [InlineData(90, 120)]
+    [InlineData(120, 60)]
+    [InlineData(61, 90)]
+    public void NextRate_CyclesAscendingAndWraps(int current, int expected) =>
+        RefreshRate.NextRate(current, [120, 60, 90, 90, 1]).Should().Be(expected);
+
+    [Fact]
+    public void NextRate_EmptySet_ReturnsNull() =>
+        RefreshRate.NextRate(60, [0, 1]).Should().BeNull();
+
+    [Theory]
+    [InlineData(new[] { 60 }, false)]
+    [InlineData(new[] { 60, 120 }, true)]
+    [InlineData(new[] { 60, 60, 1 }, false)]
+    public void HasMultipleRates_RequiresTwoDistinctRealRates(int[] rates, bool expected) =>
+        RefreshRate.HasMultipleRates(rates).Should().Be(expected);
+}

--- a/tests/XiControl.Tests/TrayMetricTests.cs
+++ b/tests/XiControl.Tests/TrayMetricTests.cs
@@ -86,4 +86,14 @@ public class TrayMetricTests
     [Fact]
     public void CpuPct_нулевой_интервал_безопасен() =>
         TrayMetricFormat.CpuPct(deltaIdle: 0, deltaBusy: 0).Should().Be(0f);
+
+    [Theory]
+    [InlineData(18_750UL, -18.75f)]
+    [InlineData(30_000UL, -30f)]
+    public void EnergyMeter_MilliwattsBecomeConsumptionWatts(ulong milliwatts, float expected) =>
+        EnergyMeterPower.ToConsumptionWatts(milliwatts).Should().Be(expected);
+
+    [Fact]
+    public void EnergyMeter_ZeroMeansUnavailable() =>
+        EnergyMeterPower.ToConsumptionWatts(0).Should().Be(float.NaN);
 }


### PR DESCRIPTION
## What

Extracted M3 from #40 as an independent power/refresh-rate change based on current `main`.

- add pure Win32 `PowerStatus` (`GetSystemPowerStatus`) and remove WinForms power-state reads from the tray paths
- enumerate supported rates of the active internal panel and expose deterministic `Supported` / `Cycle` helpers
- add a 15-second post-resume verification probe to `RefreshRateGuard`
  - normal case: the probe is one-shot and stops when the state is unchanged
  - if it observes an AC/battery transition without `StatusChange`, it becomes persistent for the rest of the session
  - a real `StatusChange` before the probe cancels the one-shot check
- use Windows Energy Meter `RAPL_Package0_PKG` as a power-metric fallback when the existing battery/adapter source has no value

## Scope

This PR intentionally contains no OEM key dispatcher (M2), OEM image pack/selector (M4), or WinUI migration (M5). M2 can wire the already-recognized `0x1A` hotkey to `RefreshRate.Cycle()` after both changes are merged.

## Verification

- `dotnet test XiControl.sln -c Release --no-build --no-restore` — 469 passed
- `dotnet build XiControl.sln -c Release --no-restore` — 0 warnings, 0 errors
- `git diff --check`